### PR TITLE
Various compatibility fix

### DIFF
--- a/clustertools/config.py
+++ b/clustertools/config.py
@@ -14,6 +14,7 @@ import yaml
 __CT_FOLDER__ = "clustertools_data"
 __CONF_NAME__ = "config.yaml"
 
+
 # /!\ Changing the default folder is not yet well supported
 
 def _get_default_config():
@@ -26,9 +27,10 @@ def _get_default_config():
         },
     }
 
+
 def get_ct_folder(conf=_get_default_config()):
     folder_name = conf["Main"]["folder"]
-    return os.path.join(os.environ["HOME"], folder_name)
+    return os.path.join(os.path.expanduser("~"), folder_name)
 
 
 def get_config():

--- a/clustertools/database.py
+++ b/clustertools/database.py
@@ -121,7 +121,7 @@ class BaseStorage(object):
         logger = logging.getLogger("clustertools")
         try:
             shutil.rmtree(self.folder)
-        except OSError, reason:
+        except OSError as reason:
             logger.warn("Trouble erasing the databases: %s" % reason,
                         exc_info=True)
 

--- a/clustertools/deprecated.py
+++ b/clustertools/deprecated.py
@@ -162,17 +162,17 @@ def erase_experiment0_0_1(exp_name):
     logger = logging.getLogger("clustertools")
     try:
         os.remove(db)
-    except OSError, reason:
+    except OSError as reason:
         logger.warn("Trouble erasing result database: %s" % reason, exc_info=True)
     db = get_notifdb0_0_1(exp_name)
     try:
         os.remove(db)
-    except OSError, reason:
+    except OSError as reason:
         logger.warn("Trouble erasing notification database: %s" % reason, exc_info=True)
     try:
         log_folder = get_log_folder0_0_1(exp_name)
         os.remove(log_folder)
-    except OSError, reason:
+    except OSError as reason:
         logger.warn("Trouble erasing log folder: %s"%reason, exc_info=True)
     # TODO move this to clusterlib
     try:
@@ -181,7 +181,7 @@ def erase_experiment0_0_1(exp_name):
         entry = (exp_name, )
         with sqlite3.connect(db, timeout=7200.0) as connection:
             connection.execute("""DELETE FROM dict WHERE key=%s"""%entry)
-    except Exception, reason:
+    except Exception as reason:
         logger.warn("Trouble erasing entry in experiment database: %s"%reason, exc_info=True)
 
 # ---------------------- from experiment.py ---------------------- #

--- a/clustertools/deprecated.py
+++ b/clustertools/deprecated.py
@@ -37,7 +37,7 @@ __RESULTS__ = "Results"
 # ---------------------- from util.py ---------------------- #
 
 def get_ct_folder0_0_1():
-    return os.path.join(os.environ["HOME"], __CT_FOLDER__)
+    return os.path.join(os.path.expanduser("~"), __CT_FOLDER__)
 
 def get_log_folder0_0_1(exp_name=None):
     try:

--- a/clustertools/notification.py
+++ b/clustertools/notification.py
@@ -196,11 +196,11 @@ class Historic(object):
     job_dict : mapping {comp_name -> mapping}
     state_dict: mapping {state -> job_dict}
     """
-    def __init__(self, exp_name, user=getpass.getuser()):
+    def __init__(self, exp_name, user=None):
         self.exp_name = exp_name
         self.job_dict = {}
         self.state_dict = {}
-        self.user = user
+        self.user = getpass.getuser() if user is None else user
         self.storage = get_storage(self.exp_name)
         self.refresh()
 

--- a/clustertools/notification.py
+++ b/clustertools/notification.py
@@ -13,8 +13,7 @@ Note
 A running job aborted for uncatchable reasons will stay in running state
 although it is not running any longer. Refresh the historic to get it right
 """
-
-import os
+import getpass
 from datetime import datetime
 import logging
 
@@ -197,7 +196,7 @@ class Historic(object):
     job_dict : mapping {comp_name -> mapping}
     state_dict: mapping {state -> job_dict}
     """
-    def __init__(self, exp_name, user=os.environ["USER"]):
+    def __init__(self, exp_name, user=getpass.getuser()):
         self.exp_name = exp_name
         self.job_dict = {}
         self.state_dict = {}
@@ -318,8 +317,9 @@ class Historic(object):
         get_storage(self.exp_name).print_log(comp_name, last_lines=last_lines)
 
 
-
-def yield_not_done_computation(experiment, user=os.environ["USER"]):
+def yield_not_done_computation(experiment, user=None):
+    if user is None:
+        user = getpass.getuser()
     historic = Historic(experiment.name, user)
     for comp_name, param in experiment:
         if historic.is_launchable(comp_name):

--- a/clustertools/parser.py
+++ b/clustertools/parser.py
@@ -11,7 +11,7 @@ from functools import partial
 
 from clusterlib.scheduler import submit
 
-from database import get_storage
+from .database import get_storage
 
 
 def parse_args(description="Cluster job launcher.", args=None, namespace=None):

--- a/clustertools/runner.py
+++ b/clustertools/runner.py
@@ -2,6 +2,7 @@
 
 """
 """
+import getpass
 
 __author__ = "Begon Jean-Michel <jm.begon@gmail.com>"
 __copyright__ = "3-clause BSD License"
@@ -28,10 +29,11 @@ class PickableCalledProcessError(CalledProcessError):
 
 
 def run_experiment(experiment, script_path, build_script=submit,
-                   force=False, user=os.environ["USER"],
+                   force=False, user=None,
                    serialize=encode_kwargs, capacity=sys.maxsize,
                    start=0):
-
+    if user is None:
+        user = getpass.getuser()
     exp_name = experiment.name
     logger = logging.getLogger("clustertools")
     logger.info("Launching experiment '%s' with script '%s'" %(experiment, script_path))


### PR DESCRIPTION
**Aim**: to be able to install clustertools on a Windows machine under either python 3.5 or 2.7

Python 3.5 compat: 
- use "except Error as e" format instead of "except Error, e"

Windows compat:
- replace usage of os.environ["HOME"] by portable os.path.expanduser()
- replace usage of os.environ["USER"] by portable getpass.getuser()

Other:
- fix import error in parser.py

