### PR TITLE
ENH Refactoring of `State` and `Computation`

### DIFF
--- a/bin/ct_count
+++ b/bin/ct_count
@@ -66,7 +66,10 @@ host are sent as once. By default, all the local experiment are listed
                 if exp_name == __WC__:
                     print(hostname, ":")
                     for name in Architecture().load_experiment_names():
-                        print("\t", name, Monitor(name).count_by_state())
+                        monitor = Monitor(name)
+                        for comp_name, progress in monitor.get_working_progress().items():
+                            print("\t", comp_name, progress)
+                        print("\t", name, monitor.count_by_state())
                 else:
                     print(hostname, ":", exp_name,
                           Monitor(exp_name).count_by_state())

--- a/clustertools/__init__.py
+++ b/clustertools/__init__.py
@@ -38,8 +38,8 @@ import logging
 # Clustertools visibility
 from .storage import Architecture
 from .state import Monitor
-from .experiment import Computation, PartialComputation, ParameterSet, \
-    ConstrainedParameterSet, Result, Experiment
+from .experiment import Computation, ParameterSet, ConstrainedParameterSet, \
+    Result, Experiment
 from .environment import Serializer, FileSerializer, InSituEnvironment
 from .datacube import Datacube, build_result_cube, build_datacube
 from .parser import BaseParser, ClusterParser
@@ -49,15 +49,15 @@ from .config import get_ct_folder, get_default_environment
 
 __author__ = "Begon Jean-Michel <jm.begon@gmail.com>"
 __copyright__ = "3-clause BSD License"
-__version__ = '0.1.1'
+__version__ = '0.1.0'
 __date__ = "08 Oct. 2015"
 
 
-__all__ = ["Monitor", "Computation", "PartialComputation", "ParameterSet",
-           "ConstrainedParameterSet", "Result", "Experiment", "Serializer",
-           "FileSerializer" "Datacube", "build_result_cube", "build_datacube",
-           "BaseParser", "ClusterParser", "call_with", "set_stdout_logging",
-           "InSituEnvironment", "get_default_environment"]
+__all__ = ["Monitor", "Computation", "ParameterSet", "ConstrainedParameterSet",
+           "Result", "Experiment", "Serializer", "FileSerializer" "Datacube",
+           "build_result_cube", "build_datacube", "BaseParser", "ClusterParser",
+           "call_with", "set_stdout_logging", "InSituEnvironment",
+           "get_default_environment"]
 
 
 logging.getLogger("clustertools").addHandler(logging.NullHandler())

--- a/clustertools/test/test_environment.py
+++ b/clustertools/test/test_environment.py
@@ -145,7 +145,8 @@ def serializer_evaluation(serializer):
     computation = TestComputation().lazyfy(x1=5, x2=10)
     computation = serializer.deserialize(serializer.serialize(computation))
     result = computation()
-    assert_equal(len(result), 1)  # only one metric
+    print(repr(result))
+    assert_equal(len(result), 2)  # One real metric + repr
     assert_equal(result.mult, 5*10)  #  correct result
 
 

--- a/clustertools/test/test_states.py
+++ b/clustertools/test/test_states.py
@@ -22,10 +22,10 @@ __copyright__ = "3-clause BSD License"
 def test_reset_state():
     for state_cls in PendingState, RunningState, CompletedState, \
                      IncompleteState, CriticalState, PartialState:
-        state = state_cls(__EXP_NAME__, "test_comp")
+        state = state_cls("test_comp")
         assert_true(isinstance(state.reset(), LaunchableState))
-    state = AbortedState(__EXP_NAME__, "test_comp",
-                         ManualInterruption("Test interruption"))
+    state = AbortedState("test_comp",
+                         exception=ManualInterruption("Test interruption"))
     assert_true(isinstance(state.reset(), LaunchableState))
 
 
@@ -33,14 +33,14 @@ def test_abort_state():
     for state_cls in PendingState, RunningState, CompletedState, \
                      IncompleteState, CriticalState, PartialState, \
                      LaunchableState:
-        state = state_cls(__EXP_NAME__, "test_comp")
+        state = state_cls("test_comp")
         state = state.abort(ManualInterruption("Test interruption"))
         assert_true(isinstance(state, AbortedState))
 
 
 def test_computation_state_routine():
     # Is this routine working ?
-    state = PendingState(__EXP_NAME__, "test_comp")
+    state = PendingState("test_comp")
     state = state.to_running()
     state = state.to_critical()
     assert_true(state.first_critical)
@@ -50,7 +50,7 @@ def test_computation_state_routine():
 
 def test_computation_state_failed_routine():
     # Is this routine working ?
-    state = PendingState(__EXP_NAME__, "test_comp")
+    state = PendingState("test_comp")
     state = state.to_running()
     state = state.abort(ManualInterruption("Test interruption"))
     assert_true(isinstance(state, AbortedState))
@@ -58,7 +58,7 @@ def test_computation_state_failed_routine():
 
 def test_partial_computation_state_routine():
     # Is this routine working ?
-    state = PendingState(__EXP_NAME__, "test_comp")
+    state = PendingState("test_comp")
     state = state.to_running()
     state = state.to_critical()
     assert_true(state.first_critical)
@@ -78,18 +78,18 @@ def monitor_refresh(monitor, can_list):
     print(monitor)
     print("Can list?", can_list)
 
-    pending = PendingState(monitor.exp_name, "test_pending")
-    running = RunningState(monitor.exp_name, "test_running")
-    completed = CompletedState(monitor.exp_name, "test_completed")
-    launchable = LaunchableState(monitor.exp_name, "test_lauchable")
-    partial = PartialState(monitor.exp_name, "test_partial")
-    first_critical = CriticalState(monitor.exp_name, "test_first_critical",
+    pending = PendingState("test_pending")
+    running = RunningState("test_running")
+    completed = CompletedState("test_completed")
+    launchable = LaunchableState("test_lauchable")
+    partial = PartialState("test_partial")
+    first_critical = CriticalState("test_first_critical",
                                    first_critical=True)
-    not_first_critical = CriticalState(monitor.exp_name, "test_not_first_critical",
+    not_first_critical = CriticalState("test_not_first_critical",
                                        first_critical=False)
-    aborted = AbortedState(monitor.exp_name, "test_aborted",
-                           ManualInterruption("Test interruption"))
-    incomplete = IncompleteState(monitor.exp_name, "incomplete")
+    aborted = AbortedState("test_aborted",
+                           exception=ManualInterruption("Test interruption"))
+    incomplete = IncompleteState("incomplete")
 
     storage = PickleStorage(monitor.exp_name)
     for state in pending, running, completed, launchable, partial, \
@@ -144,13 +144,13 @@ def test_monitor_refresh_cannot_list():
 
 @with_setup_(pickle_prep, pickle_purge)
 def monitor_incomplete_to_launchable(monitor, can_list):
-    incomplete = IncompleteState(monitor.exp_name, "incomplete")
-    partial = PartialState(monitor.exp_name, "test_partial")
-    not_first_critical = CriticalState(monitor.exp_name, "test_not_first_critical",
+    incomplete = IncompleteState("incomplete")
+    partial = PartialState("test_partial")
+    not_first_critical = CriticalState("test_not_first_critical",
                                        first_critical=False)
-    first_critical = CriticalState(monitor.exp_name, "test_first_critical",
+    first_critical = CriticalState("test_first_critical",
                                    first_critical=True)
-    aborted = AbortedState(monitor.exp_name, "test_aborted",
+    aborted = AbortedState("test_aborted",
                            ManualInterruption("Test interruption"))
 
     storage = PickleStorage(monitor.exp_name)
@@ -212,9 +212,9 @@ def test_monitor_incomplete_to_launchable_cannot_list():
 
 @with_setup(pickle_prep, pickle_purge)
 def test_monitor_aborted_to_launchable():
-    incomplete = IncompleteState(__EXP_NAME__, "incomplete")
-    completed = CompletedState(__EXP_NAME__, "completed")
-    aborted = AbortedState(__EXP_NAME__, "test_aborted",
+    incomplete = IncompleteState("incomplete")
+    completed = CompletedState("completed")
+    aborted = AbortedState("test_aborted",
                            ManualInterruption("Test interruption"))
 
     storage = PickleStorage(__EXP_NAME__)

--- a/clustertools/test/test_storage.py
+++ b/clustertools/test/test_storage.py
@@ -49,9 +49,9 @@ def test_save_then_load_result_and_params():
 @with_setup(pickle_prep, pickle_purge)
 def test_save_then_load_state():
     storage = PickleStorage(__EXP_NAME__)
-    pending = PendingState(__EXP_NAME__, "pending")
+    pending = PendingState("pending")
     abort_exp = ManualInterruption("Test")
-    aborted = AbortedState(__EXP_NAME__, "aborted", abort_exp)
+    aborted = AbortedState("aborted", abort_exp)
     # First storage
     storage.update_state(pending)
     storage.update_state(aborted)

--- a/clustertools/test/util_test.py
+++ b/clustertools/test/util_test.py
@@ -5,7 +5,7 @@ from unittest import SkipTest
 
 from nose import with_setup
 
-from clustertools.experiment import Result, Computation, PartialComputation
+from clustertools.experiment import Computation
 from clustertools.storage import Storage, Architecture, PickleStorage
 
 __author__ = "Begon Jean-Michel <jm.begon@gmail.com>"
@@ -105,24 +105,5 @@ class TestComputation(Computation):
                                               context=context,
                                               storage_factory=storage_factory)
 
-    def run(self, x1, x2, **ignored):
-        result = Result("mult")
-        result.mult = x1*x2
-        return result
-
-
-class TestPartialComputation(PartialComputation):
-    def __init__(self, exp_name=__EXP_NAME__, comp_name="TestComp",
-                 context="n/a", storage_factory=IntrospectStorage):
-        super(TestPartialComputation, self).__init__(exp_name=exp_name,
-                                                     comp_name=comp_name,
-                                                     context=context,
-                                                     storage_factory=storage_factory)
-
-    def run(self, n, **ignored):
-        result = Result("i")
-        for i in range(n):
-            if i >= 3:
-                raise ValueError("Parameter n cannot be greater than 3.")
-            result.i = i
-            yield result
+    def run(self, result, x1, x2, **ignored):
+        result["mult"] = x1 * x2

--- a/examples/basic_bash.py
+++ b/examples/basic_bash.py
@@ -21,23 +21,18 @@ class BasicComputation(Computation):
     Inherit from `Computation` and redefine the `run` method as you which
     """
 
-    def run(self, x, z, w, y=2, **parameters):
+    def run(self, result, x, z, w, y=2, **parameters):
         # For dill, import must be in the scope of the serialized object
-        from clustertools import Result
         import time
         from random import randint
-        # Create the result object which will holds the actual results of the
-        # computation
-        results = Result("multiply", "sum")
 
         # Do some heavy number crunching
-        results.multiply = x * y
-        results["sum"] = z + w
+        result["multiply"] = x * y
+        result["sum"] = z + w
         time.sleep(randint(1, 10))
+        # Result is automatically collected.
+        # Everything (saving, updating status, etc.) is taken care of
 
-        # Return the result. Everything (saving, updating status, etc.) is
-        # taken care of
-        return results
 
 
 if __name__ == "__main__":

--- a/examples/basic_cluster.py
+++ b/examples/basic_cluster.py
@@ -23,23 +23,19 @@ class BasicComputation(Computation):
     Inherit from `Computation` and redefine the `run` method as you which
     """
 
-    def run(self, x, z, w, y=2, **parameters):
+    def run(self, result, x, z, w, y=2, **parameters):
         # For dill, import must be in the scope of the serialized object
-        from clustertools import Result
         import time
         from random import randint
         # Create the result object which will holds the actual results of the
         # computation
-        results = Result("multiply", "sum")
-
         # Do some heavy number crunching
-        results.multiply = x * y
-        results["sum"] = z + w
+        result["multiply"] = x * y
+        result["sum"] = z + w
         time.sleep(randint(1, 10))
 
-        # Return the result. Everything (saving, updating status, etc.) is
-        # taken care of
-        return results
+        # Result is automatically collected.
+        # Everything (saving, updating status, etc.) is taken care of
 
 
 if __name__ == "__main__":

--- a/examples/pure_sequential.py
+++ b/examples/pure_sequential.py
@@ -20,24 +20,19 @@ class BasicComputation(Computation):
     Inherit from `Computation` and redefine the `run` method as you which
     """
 
-    def run(self, x, z, w, y=2, **parameters):
+    def run(self, result, x, z, w, y=2, **parameters):
         # For dill, import must be in the scope of the serialized object
-        from clustertools import Result
         import time
         from random import randint
-        # Create the result object which will holds the actual results of the
-        # computation
-        results = Result("multiply", "sum")
 
         # Do some heavy number crunching
-        results.multiply = x * y
-        results["sum"] = z + w
+        result["multiply"] = x * y
+        result["sum"] = z + w
         time.sleep(randint(1, 10))
         print("HARRY POTTER !")
 
-        # Return the result. Everything (saving, updating status, etc.) is
-        # taken care of
-        return results
+        # Result is automatically collected.
+        # Everything (saving, updating status, etc.) is taken care of
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
 `State`s no longer hold a useless `exp_name` field and a `progress` field has been added. It is the responsibility of the user to maintain it correctly (through the :meth:`notify_progress` method of the `Computation`. Other files (tests, ct_cout) have been modified accordingly.

  `Computation`s now offer the possibility to save partial results directly (the `PartialComputation` class has been removed accordingly). Also it gets the `Result` instance to store its computations directly. There is not yet a mechanism to resume automatically an interrupted computation but all the needed resources are in place. Other files (examples, tests) have been modified accordinlgy